### PR TITLE
Standard Mediative SBT project setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+# Use container-based infrastructure
+sudo: false
+
+language: scala
+scala: 2.11.7
+jdk: oraclejdk8
+
+script:
+  - sbt ++$TRAVIS_SCALA_VERSION reformat-code-check test
+
+  # Tricks to avoid unnecessary cache updates
+  - find $HOME/.sbt -name "*.lock" | xargs rm
+  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+
+# These directories are cached at the end of the build
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+Bugs and feature requests should be reported in the [GitHub issue
+tracker](https://github.com/ypg-data/eigenflow/issues/new) and
+answer the following questions:
+
+ - Motivation: Why should this be addressed? What is the purpose?
+ - Input: What are the pre-conditions?
+ - Output: What is the expected outcome after the issue has been addressed?
+ - Test: How can the results listed in the "Output" be QA'ed?
+
+For code contributions, these are the suggested steps:
+
+ - Identify the change you'd like to make, e.g. fix a bug or add a feature.
+   Larger contributions should always begin with [first creating an
+   issue](https://github.com/ypg-data/eigenflow/issues/new) to ensure
+   that the change is properly scoped.
+ - Fork the repository on GitHub.
+ - Develop your change on a feature branch.
+ - Write tests to validate your change works as expected.
+ - Create a pull request.
+ - Address any issues raised during the code review.
+ - Once you get a "+1" on the pull request, the change can be merged.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ organization in ThisBuild := "com.mediative"
 name in ThisBuild         := "eigenflow"
 scalaVersion in ThisBuild := "2.11.7"
 
+Jvm.`1.8`.required
+
 // Dependencies
 resolvers += Resolver.bintrayRepo("krasserm", "maven")
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,29 +1,9 @@
-name := "eigenflow"
-
-organization := "com.mediative"
-
-version := "0.1.0"
-
-scalaVersion := "2.11.7"
-
-scalacOptions ++= Seq(
-  "-feature",
-  "-unchecked",
-  "-deprecation",
-  "-encoding", "UTF-8",
-  "-Xfatal-warnings",
-  "-Xlint",
-  "-Xfuture",
-  "-Yno-adapted-args",
-  "-Ywarn-dead-code",
-  "-Ywarn-value-discard"
-  )
-
-scalariformSettings
-
+organization in ThisBuild := "com.mediative"
+name in ThisBuild         := "eigenflow"
+scalaVersion in ThisBuild := "2.11.7"
 
 // Dependencies
-resolvers += "krasserm at bintray" at "http://dl.bintray.com/krasserm/maven"
+resolvers += Resolver.bintrayRepo("krasserm", "maven")
 
 val akkaVersion = "2.4.1"
 val kafkaVersion = "0.9.0.0"
@@ -41,3 +21,5 @@ libraryDependencies ++= Seq(
   // json
   "com.lihaoyi" %% "upickle" % "0.3.6"
 )
+
+enablePlugins(MediativeReleasePlugin, MediativeBintrayPlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,5 @@
+resolvers += Resolver.url("YPG-Data SBT Plugins", url("https://dl.bintray.com/ypg-data/sbt-plugins"))(Resolver.ivyStylePatterns)
+
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.1")
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("com.mediative.sbt" % "sbt-mediative-core" % "0.1.1")
+addSbtPlugin("com.mediative.sbt" % "sbt-mediative-oss" % "0.1.1")

--- a/src/main/scala/com.mediative.eigenflow/EigenflowBootstrap.scala
+++ b/src/main/scala/com.mediative.eigenflow/EigenflowBootstrap.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow
 
 import akka.actor.{ Props, ActorSystem }

--- a/src/main/scala/com.mediative.eigenflow/StagedProcess.scala
+++ b/src/main/scala/com.mediative.eigenflow/StagedProcess.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow
 
 import java.util.Date

--- a/src/main/scala/com.mediative.eigenflow/domain/ProcessContext.scala
+++ b/src/main/scala/com.mediative.eigenflow/domain/ProcessContext.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.domain
 
 import java.util.Date

--- a/src/main/scala/com.mediative.eigenflow/domain/Retry.scala
+++ b/src/main/scala/com.mediative.eigenflow/domain/Retry.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.domain
 
 import scala.concurrent.duration.FiniteDuration

--- a/src/main/scala/com.mediative.eigenflow/domain/RetryRegistry.scala
+++ b/src/main/scala/com.mediative.eigenflow/domain/RetryRegistry.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.domain
 
 /**

--- a/src/main/scala/com.mediative.eigenflow/domain/fsm/ExecutionPlan.scala
+++ b/src/main/scala/com.mediative.eigenflow/domain/fsm/ExecutionPlan.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.domain.fsm
 
 import com.mediative.eigenflow.domain.{ ProcessContext, Retry }

--- a/src/main/scala/com.mediative.eigenflow/domain/fsm/ProcessEvent.scala
+++ b/src/main/scala/com.mediative.eigenflow/domain/fsm/ProcessEvent.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.domain.fsm
 
 import com.mediative.eigenflow.domain.Retry

--- a/src/main/scala/com.mediative.eigenflow/domain/fsm/ProcessStage.scala
+++ b/src/main/scala/com.mediative.eigenflow/domain/fsm/ProcessStage.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.domain.fsm
 
 import akka.persistence.fsm.PersistentFSM.FSMState

--- a/src/main/scala/com.mediative.eigenflow/domain/messages/GenericMessage.scala
+++ b/src/main/scala/com.mediative.eigenflow/domain/messages/GenericMessage.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.domain.messages
 
 /**

--- a/src/main/scala/com.mediative.eigenflow/domain/messages/MetricsMessage.scala
+++ b/src/main/scala/com.mediative.eigenflow/domain/messages/MetricsMessage.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.domain.messages
 
 /**

--- a/src/main/scala/com.mediative.eigenflow/domain/messages/ProcessMessage.scala
+++ b/src/main/scala/com.mediative.eigenflow/domain/messages/ProcessMessage.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.domain.messages
 
 /**

--- a/src/main/scala/com.mediative.eigenflow/domain/messages/StageMessage.scala
+++ b/src/main/scala/com.mediative.eigenflow/domain/messages/StageMessage.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.domain.messages
 
 /**

--- a/src/main/scala/com.mediative.eigenflow/domain/messages/StateRecord.scala
+++ b/src/main/scala/com.mediative.eigenflow/domain/messages/StateRecord.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.domain.messages
 
 /**

--- a/src/main/scala/com.mediative.eigenflow/dsl/EigenFlowDSL.scala
+++ b/src/main/scala/com.mediative.eigenflow/dsl/EigenFlowDSL.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.dsl
 
 import com.mediative.eigenflow.domain.{ Retry, ProcessContext }

--- a/src/main/scala/com.mediative.eigenflow/environment/ConfigurationLoader.scala
+++ b/src/main/scala/com.mediative.eigenflow/environment/ConfigurationLoader.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.environment
 
 import com.typesafe.config.ConfigFactory

--- a/src/main/scala/com.mediative.eigenflow/environment/ProcessConfiguration.scala
+++ b/src/main/scala/com.mediative.eigenflow/environment/ProcessConfiguration.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.environment
 
 case class ProcessConfiguration(id: String, dataPath: String)

--- a/src/main/scala/com.mediative.eigenflow/helpers/DateHelper.scala
+++ b/src/main/scala/com.mediative.eigenflow/helpers/DateHelper.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.helpers
 
 import java.text.SimpleDateFormat

--- a/src/main/scala/com.mediative.eigenflow/helpers/PrimitiveImplicits.scala
+++ b/src/main/scala/com.mediative.eigenflow/helpers/PrimitiveImplicits.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.helpers
 
 import scala.language.implicitConversions

--- a/src/main/scala/com.mediative.eigenflow/process/ProcessFSM.scala
+++ b/src/main/scala/com.mediative.eigenflow/process/ProcessFSM.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.process
 
 import java.util.{ Date, UUID }

--- a/src/main/scala/com.mediative.eigenflow/process/ProcessManager.scala
+++ b/src/main/scala/com.mediative.eigenflow/process/ProcessManager.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.process
 
 import java.util.Date

--- a/src/main/scala/com.mediative.eigenflow/publisher/MessagingSystem.scala
+++ b/src/main/scala/com.mediative.eigenflow/publisher/MessagingSystem.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.publisher
 
 trait MessagingSystem {

--- a/src/main/scala/com.mediative.eigenflow/publisher/PrintMessagingSystem.scala
+++ b/src/main/scala/com.mediative.eigenflow/publisher/PrintMessagingSystem.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.publisher
 
 import akka.event.LoggingAdapter

--- a/src/main/scala/com.mediative.eigenflow/publisher/ProcessPublisher.scala
+++ b/src/main/scala/com.mediative.eigenflow/publisher/ProcessPublisher.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.publisher
 
 import java.util.Date

--- a/src/main/scala/com.mediative.eigenflow/publisher/kafka/KafkaConfiguration.scala
+++ b/src/main/scala/com.mediative.eigenflow/publisher/kafka/KafkaConfiguration.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.publisher.kafka
 
 import java.util.Properties

--- a/src/main/scala/com.mediative.eigenflow/publisher/kafka/KafkaMessagingSystem.scala
+++ b/src/main/scala/com.mediative.eigenflow/publisher/kafka/KafkaMessagingSystem.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mediative.eigenflow.publisher.kafka
 
 import akka.event.LoggingAdapter


### PR DESCRIPTION
Enables the sbt-mediative plugins and setup standard stuff like licensing, contribution instructions and build checks.
