### PR TITLE
Reworked the Kafka Topic Structure.

### DIFF
--- a/doc/messaging.md
+++ b/doc/messaging.md
@@ -26,7 +26,7 @@ For example:
 ```scala
 val stage = Stage {
   Future { ... }
-} publishMetrics("statistics", _ => Map("total" -> 1.0))
+} publishMetrics(_ => Map("total" -> 1.0))
 ```
 
 In this case a message with process, stage and metrics information will be published to `process_id-statistics` topic.
@@ -62,6 +62,7 @@ eigenflow {
 
   kafka {
     bootstrap.servers = "..."
+    topic.prefix = "..." // Optional. The Default value is "eigenflow".
   }
 }
 ```

--- a/src/main/resources/mesos.conf
+++ b/src/main/resources/mesos.conf
@@ -38,5 +38,6 @@ eigenflow {
 
   kafka {
     bootstrap.servers = "broker-1.kafka.mesos:6000,broker-2.kafka.mesos:6000"
+    topic.prefix = "eigenflow"
   }
 }

--- a/src/main/scala/com.mediative.eigenflow/domain/fsm/ExecutionPlan.scala
+++ b/src/main/scala/com.mediative.eigenflow/domain/fsm/ExecutionPlan.scala
@@ -55,4 +55,4 @@ case class ExecutionPlan[A, B](
   from: String => A, to: B => String,
   recoveryStrategy: Throwable => RecoveryStrategy = RecoveryStrategy.default, recoveryTimeout: Option[Long] = None,
   previous: Option[ExecutionPlan[_, A]] = None,
-  publishMetricsMap: Option[(String, B => Map[String, Double])] = None)
+  publishMetricsMap: Option[B => Map[String, Double]] = None)

--- a/src/main/scala/com.mediative.eigenflow/domain/messages/MetricsMessage.scala
+++ b/src/main/scala/com.mediative.eigenflow/domain/messages/MetricsMessage.scala
@@ -22,4 +22,9 @@ package com.mediative.eigenflow.domain.messages
  *
  * @see GenericMessage
  */
-case class MetricsMessage(timestamp: Long, processId: String, stage: String, message: Map[String, Double])
+case class MetricsMessage(
+  timestamp: Long,
+  jobId: String,
+  processId: String,
+  stage: String,
+  message: Map[String, Double])

--- a/src/main/scala/com.mediative.eigenflow/domain/messages/ProcessMessage.scala
+++ b/src/main/scala/com.mediative.eigenflow/domain/messages/ProcessMessage.scala
@@ -20,6 +20,7 @@ package com.mediative.eigenflow.domain.messages
  * Message for process state changes.
  *
  * @param timestamp Time when the message was created.
+ * @param jobId Job identifier
  * @param processId Process identification.
  * @param processingDate Processing date of the process.
  * @param state Process state.
@@ -31,6 +32,7 @@ package com.mediative.eigenflow.domain.messages
  */
 case class ProcessMessage(
   timestamp: Long,
+  jobId: String,
   processId: String,
   processingDate: String,
   state: String,

--- a/src/main/scala/com.mediative.eigenflow/domain/messages/StageMessage.scala
+++ b/src/main/scala/com.mediative.eigenflow/domain/messages/StageMessage.scala
@@ -27,7 +27,9 @@ package com.mediative.eigenflow.domain.messages
  *                 Initial state's duration should be 0.
  * @param message Data passed between stages.
  */
-case class StageMessage(timestamp: Long,
+case class StageMessage(
+  timestamp: Long,
+  jobId: String,
   processId: String,
   stage: String,
   state: String,

--- a/src/main/scala/com.mediative.eigenflow/dsl/EigenflowDSL.scala
+++ b/src/main/scala/com.mediative.eigenflow/dsl/EigenflowDSL.scala
@@ -54,11 +54,10 @@ trait EigenflowDSL {
     /**
      * Publish custom data to the given topic.
      *
-     * @param topic Topic to publish messages to.
      * @param f Function to build a key map value from the stage execution result.
      */
-    def publishMetrics(topic: String, f: B => Map[String, Double]): ExecutionPlan[A, B] =
-      executionPlan.copy(publishMetricsMap = Some((topic, f)))
+    def publishMetrics(f: B => Map[String, Double]): ExecutionPlan[A, B] =
+      executionPlan.copy(publishMetricsMap = Some(f))
 
     /**
      * Define recovery timeout. Makes sense only in combination with 'onFailure' method.

--- a/src/main/scala/com.mediative.eigenflow/publisher/kafka/KafkaConfiguration.scala
+++ b/src/main/scala/com.mediative.eigenflow/publisher/kafka/KafkaConfiguration.scala
@@ -32,7 +32,8 @@ object KafkaConfiguration {
       "linger.ms",
       "buffer.memory",
       "key.serializer",
-      "value.serializer")
+      "value.serializer",
+      "topic.prefix")
 
     val properties = new Properties()
     propertiesKeys.foreach(key => properties.setProperty(key, config.getString(s"eigenflow.kafka.${key}")))

--- a/src/main/scala/com.mediative.eigenflow/publisher/kafka/KafkaMessagingSystem.scala
+++ b/src/main/scala/com.mediative.eigenflow/publisher/kafka/KafkaMessagingSystem.scala
@@ -21,15 +21,19 @@ import com.mediative.eigenflow.publisher.MessagingSystem
 import org.apache.kafka.clients.producer.{ Callback, KafkaProducer, ProducerRecord, RecordMetadata }
 
 class KafkaMessagingSystem(log: LoggingAdapter) extends MessagingSystem {
-  private val producer = new KafkaProducer[String, String](KafkaConfiguration.properties)
+  private val config = KafkaConfiguration.properties()
+  private val producer = new KafkaProducer[String, String](config)
+  private val topicPrefix = config.getProperty("topic.prefix")
 
   override def publish(topic: String, message: String): Unit = {
-    log.info(s"Publishing to $topic :\n$message\n")
+    val topicName = s"$topicPrefix-$topic"
 
-    producer.send(new ProducerRecord[String, String](topic, message), new Callback {
+    log.info(s"Publishing to $topicName :\n$message\n")
+
+    producer.send(new ProducerRecord[String, String](topicName, message), new Callback {
       override def onCompletion(metadata: RecordMetadata, exception: Exception): Unit = {
         if (exception != null) {
-          log.error(s"Cannot publish to $topic. Caused by: ${exception.getMessage}", exception)
+          log.error(s"Cannot publish to $topicName. Caused by: ${exception.getMessage}", exception)
         }
       }
     })

--- a/src/test/scala/com.mediative.eigenflow.test/publisher/ProcessPublisherTest.scala
+++ b/src/test/scala/com.mediative.eigenflow.test/publisher/ProcessPublisherTest.scala
@@ -1,0 +1,220 @@
+package com.mediative.eigenflow.test.publisher
+
+import java.util.Date
+
+import com.mediative.eigenflow.domain.ProcessContext
+import com.mediative.eigenflow.domain.messages._
+import com.mediative.eigenflow.helpers.DateHelper._
+import com.mediative.eigenflow.publisher.{ MessagingSystem, ProcessPublisher }
+import org.scalatest.FreeSpec
+import upickle.default._
+
+import scala.collection.mutable
+import scala.language.{ implicitConversions, reflectiveCalls }
+
+class ProcessPublisherTest extends FreeSpec {
+
+  class TestContext {
+    val processContext = ProcessContext.default(new Date(0))
+
+    val mockMessagingSystem = new MessagingSystem {
+      val publishedMessages = mutable.ArrayBuffer[(String, String)]()
+
+      override def publish(topic: String, message: String): Unit = {
+        publishedMessages.append(topic -> message)
+      }
+    }
+
+    val publisher = new ProcessPublisher {
+      override def jobId: String = "TestJob"
+
+      override def publisher: MessagingSystem = mockMessagingSystem
+    }
+  }
+
+  def context(f: (TestContext) => Unit): Unit = {
+    f(new TestContext)
+  }
+
+  def defaultProcessMessage(context: TestContext): ProcessMessage = {
+    ProcessMessage(
+      timestamp = 0,
+      jobId = context.publisher.jobId,
+      processId = context.processContext.processId,
+      processingDate = TimeFormat.format(context.processContext.processingDate),
+      state = Processing.identifier,
+      duration = 0,
+      message = ""
+    )
+  }
+
+  def defaultStageMessage(context: TestContext): StageMessage = {
+    StageMessage(
+      timestamp = 0,
+      jobId = context.publisher.jobId,
+      processId = context.processContext.processId,
+      stage = context.processContext.stage.identifier,
+      state = Processing.identifier,
+      duration = 0,
+      message = ""
+    )
+  }
+
+  implicit class ProcessMessageHelper(message: ProcessMessage) {
+    def ignoreTimeFields(): ProcessMessage = message.copy(timestamp = 0, duration = 0)
+  }
+  implicit class StageMessageHelper(message: StageMessage) {
+    def ignoreTimeFields(): StageMessage = message.copy(timestamp = 0, duration = 0)
+  }
+  implicit class MetricsMessageHelper(message: MetricsMessage) {
+    def ignoreTimeFields(): MetricsMessage = message.copy(timestamp = 0)
+  }
+
+  "publishProcessStarting" - {
+    "publish the expected message" in context { context =>
+      context.publisher.publishProcessStarting(context.processContext)
+
+      val expectedMessage = defaultProcessMessage(context).copy(
+        state = Processing.identifier
+      )
+
+      val actualMessages = context.mockMessagingSystem.publishedMessages.map {
+        case (key, value) => key -> read[ProcessMessage](value).ignoreTimeFields()
+      }
+
+      assert(actualMessages === List("jobs" -> expectedMessage))
+    }
+  }
+  "publishProcessComplete" - {
+    "publish the expected message" in context { context =>
+      val nextProcessingDate = new Date()
+      context.publisher.publishProcessComplete(context.processContext, nextProcessingDate)
+
+      val expectedMessage = defaultProcessMessage(context).copy(
+        state = Complete.identifier,
+        message = TimeFormat.format(nextProcessingDate)
+      )
+
+      val actualMessages = context.mockMessagingSystem.publishedMessages.map {
+        case (key, value) => key -> read[ProcessMessage](value).ignoreTimeFields()
+      }
+
+      assert(actualMessages === List("jobs" -> expectedMessage))
+    }
+  }
+  "publishProcessFailed" - {
+    "publish the expected message" in context { context =>
+      val failure = new RuntimeException("Boom")
+
+      context.publisher.publishProcessFailed(context.processContext, failure)
+
+      val expectedMessage = defaultProcessMessage(context).copy(
+        state = Failed.identifier,
+        message = s"${failure.getClass.getName}: ${failure.getMessage}"
+      )
+
+      val actualMessages = context.mockMessagingSystem.publishedMessages.map {
+        case (key, value) => key -> read[ProcessMessage](value).ignoreTimeFields()
+      }
+
+      assert(actualMessages === List("jobs" -> expectedMessage))
+    }
+  }
+  "publishStageStarting" - {
+    "publish the expected message" in context { context =>
+      val message = "Some Message"
+
+      context.publisher.publishStageStarting(context.processContext.processId, context.processContext.stage, message)
+
+      val expectedMessage = defaultStageMessage(context).copy(
+        state = Processing.identifier,
+        message = message
+      )
+
+      val actualMessages = context.mockMessagingSystem.publishedMessages.map {
+        case (key, value) => key -> read[StageMessage](value).ignoreTimeFields()
+      }
+
+      assert(actualMessages === List("stages" -> expectedMessage))
+    }
+  }
+  "publishStageComplete" - {
+    "publish the expected message" in context { context =>
+      val message = "Some Message"
+
+      context.publisher.publishStageComplete(context.processContext, message)
+
+      val expectedMessage = defaultStageMessage(context).copy(
+        state = Complete.identifier,
+        message = message
+      )
+
+      val actualMessages = context.mockMessagingSystem.publishedMessages.map {
+        case (key, value) => key -> read[StageMessage](value).ignoreTimeFields()
+      }
+
+      assert(actualMessages === List("stages" -> expectedMessage))
+    }
+  }
+  "publishStageRetrying" - {
+    "publish the expected message" in context { context =>
+      context.publisher.publishStageRetrying(context.processContext)
+
+      val expectedMessage = defaultStageMessage(context).copy(
+        state = Retrying.identifier,
+        message = context.processContext.message
+      )
+
+      val actualMessages = context.mockMessagingSystem.publishedMessages.map {
+        case (key, value) => key -> read[StageMessage](value).ignoreTimeFields()
+      }
+
+      assert(actualMessages === List("stages" -> expectedMessage))
+    }
+  }
+  "publishStageFailed" - {
+    "publish the expected message" in context { context =>
+      val failure = new RuntimeException("Boom")
+
+      context.publisher.publishStageFailed(context.processContext, failure)
+
+      val expectedMessage = defaultStageMessage(context).copy(
+        state = Failed.identifier,
+        message = s"${failure.getClass.getName}: ${failure.getMessage}"
+      )
+
+      val actualMessages = context.mockMessagingSystem.publishedMessages.map {
+        case (key, value) => key -> read[StageMessage](value).ignoreTimeFields()
+      }
+
+      assert(actualMessages === List("stages" -> expectedMessage))
+    }
+  }
+  "publishMetrics" - {
+    "publish the expected message" in context { context =>
+      val metricType = "Type"
+
+      val message = Map(
+        "k1" -> 1.0d,
+        "k2" -> 2.0d,
+        "k2" -> 3.0d
+      )
+
+      context.publisher.publishMetrics(context.processContext, message)
+
+      val expectedMessage = MetricsMessage(
+        timestamp = 0,
+        jobId = context.publisher.jobId,
+        processId = context.processContext.processId,
+        stage = context.processContext.stage.identifier,
+        message = message)
+
+      val actualMessages = context.mockMessagingSystem.publishedMessages.map {
+        case (key, value) => key -> read[MetricsMessage](value).ignoreTimeFields()
+      }
+
+      assert(actualMessages === List("metrics" -> expectedMessage))
+    }
+  }
+
+}


### PR DESCRIPTION
Rather than using Topics that include the job id the name, we will instead use more generic topics.  We will then include the jobId inside the message being sent to the topic.

This enables us to create more generic consumers.  The consumers don't need to know in advance what the jobs will be.
