### PR TITLE
Fix for Issue #29: EigenflowBootstrap initialization

### DIFF
--- a/src/it/scala/com.mediative.eigenflow.test.it/utils/wrappers/TracedProcessFSM.scala
+++ b/src/it/scala/com.mediative.eigenflow.test.it/utils/wrappers/TracedProcessFSM.scala
@@ -19,6 +19,7 @@ package com.mediative.eigenflow.test.it.utils.wrappers
 import java.util.Date
 
 import akka.actor.Props
+import akka.event.LoggingAdapter
 import com.mediative.eigenflow.StagedProcess
 import com.mediative.eigenflow.domain.ProcessContext
 import com.mediative.eigenflow.domain.fsm.{ ProcessEvent, ProcessStage }
@@ -29,7 +30,7 @@ import com.mediative.eigenflow.publisher.MessagingSystem
 object TracedProcessFSM {
 
   implicit def messagingSystem = new MessagingSystem {
-    override def publish(topic: String, message: String): Unit = () // ignore
+    override def publish(topic: String, message: String)(implicit log: LoggingAdapter): Unit = () // ignore
   }
 
   def props(process: StagedProcess, date: Date, reset: Boolean = false) = Props(new TracedProcessFSM(process, date, reset))

--- a/src/it/scala/com.mediative.eigenflow.test.it/utils/wrappers/TracedProcessManager.scala
+++ b/src/it/scala/com.mediative.eigenflow.test.it/utils/wrappers/TracedProcessManager.scala
@@ -3,6 +3,7 @@ package com.mediative.eigenflow.test.it.utils.wrappers
 import java.util.Date
 
 import akka.actor.{ ActorRef, Props }
+import akka.event.LoggingAdapter
 import com.mediative.eigenflow.StagedProcess
 import com.mediative.eigenflow.process.ProcessManager
 import com.mediative.eigenflow.process.ProcessManager.ProcessingDateState
@@ -10,7 +11,7 @@ import com.mediative.eigenflow.publisher.MessagingSystem
 
 object TracedProcessManager {
   private implicit def messagingSystem = new MessagingSystem {
-    override def publish(topic: String, message: String): Unit = () // ignore
+    override def publish(topic: String, message: String)(implicit log: LoggingAdapter): Unit = () // ignore
   }
 
   def props(process: StagedProcess,

--- a/src/main/scala/com.mediative.eigenflow/EigenflowBootstrap.scala
+++ b/src/main/scala/com.mediative.eigenflow/EigenflowBootstrap.scala
@@ -38,9 +38,10 @@ trait EigenflowBootstrap {
   def process: StagedProcess
 
   // bootstrap the system: initialize akka, message publisher ...
+  implicit val messagingSystem = Class.forName(ConfigurationLoader.config.getString("eigenflow.messaging")).asInstanceOf[MessagingSystem]
+
+  // initialize actor system after messaging system (fix for Issue #29)
   implicit val system = ActorSystem("DataFlow", ConfigurationLoader.config)
-  implicit val messagingSystem = Class.forName(ConfigurationLoader.config.getString("eigenflow.messaging")).
-    getConstructor(classOf[LoggingAdapter]).newInstance(system.log).asInstanceOf[MessagingSystem]
 
   // load environment variables
   private val startDate = Option(System.getenv("start")).flatMap(parse)

--- a/src/main/scala/com.mediative.eigenflow/publisher/MessagingSystem.scala
+++ b/src/main/scala/com.mediative.eigenflow/publisher/MessagingSystem.scala
@@ -16,7 +16,9 @@
 
 package com.mediative.eigenflow.publisher
 
+import akka.event.LoggingAdapter
+
 trait MessagingSystem {
-  def publish(topic: String, message: String): Unit
+  def publish(topic: String, message: String)(implicit log: LoggingAdapter): Unit
   def stop(): Unit = ()
 }

--- a/src/main/scala/com.mediative.eigenflow/publisher/PrintMessagingSystem.scala
+++ b/src/main/scala/com.mediative.eigenflow/publisher/PrintMessagingSystem.scala
@@ -18,8 +18,8 @@ package com.mediative.eigenflow.publisher
 
 import akka.event.LoggingAdapter
 
-class PrintMessagingSystem(log: LoggingAdapter) extends MessagingSystem {
-  override def publish(topic: String, message: String): Unit = {
+class PrintMessagingSystem extends MessagingSystem {
+  override def publish(topic: String, message: String)(implicit log: LoggingAdapter): Unit = {
     log.info(s"Publishing to $topic :\n$message\n")
   }
 }

--- a/src/main/scala/com.mediative.eigenflow/publisher/ProcessPublisher.scala
+++ b/src/main/scala/com.mediative.eigenflow/publisher/ProcessPublisher.scala
@@ -18,6 +18,7 @@ package com.mediative.eigenflow.publisher
 
 import java.util.Date
 
+import akka.event.LoggingAdapter
 import com.mediative.eigenflow.domain.ProcessContext
 import com.mediative.eigenflow.domain.fsm.ProcessStage
 import com.mediative.eigenflow.domain.messages._
@@ -27,6 +28,8 @@ import upickle.default._
 import scala.language.implicitConversions
 
 trait ProcessPublisher {
+  implicit def log: LoggingAdapter
+
   def publisher: MessagingSystem
 
   def jobId: String

--- a/src/main/scala/com.mediative.eigenflow/publisher/kafka/KafkaMessagingSystem.scala
+++ b/src/main/scala/com.mediative.eigenflow/publisher/kafka/KafkaMessagingSystem.scala
@@ -20,12 +20,12 @@ import akka.event.LoggingAdapter
 import com.mediative.eigenflow.publisher.MessagingSystem
 import org.apache.kafka.clients.producer.{ Callback, KafkaProducer, ProducerRecord, RecordMetadata }
 
-class KafkaMessagingSystem(log: LoggingAdapter) extends MessagingSystem {
+class KafkaMessagingSystem extends MessagingSystem {
   private val config = KafkaConfiguration.properties()
   private val producer = new KafkaProducer[String, String](config)
   private val topicPrefix = config.getProperty("topic.prefix")
 
-  override def publish(topic: String, message: String): Unit = {
+  override def publish(topic: String, message: String)(implicit log: LoggingAdapter): Unit = {
     val topicName = s"$topicPrefix-$topic"
 
     log.info(s"Publishing to $topicName :\n$message\n")

--- a/src/test/scala/com.mediative.eigenflow.test/publisher/ProcessPublisherTest.scala
+++ b/src/test/scala/com.mediative.eigenflow.test/publisher/ProcessPublisherTest.scala
@@ -2,11 +2,13 @@ package com.mediative.eigenflow.test.publisher
 
 import java.util.Date
 
+import akka.event.LoggingAdapter
 import com.mediative.eigenflow.domain.ProcessContext
 import com.mediative.eigenflow.domain.messages._
 import com.mediative.eigenflow.helpers.DateHelper._
 import com.mediative.eigenflow.publisher.{ MessagingSystem, ProcessPublisher }
 import org.scalatest.FreeSpec
+import org.scalatest.mock.MockitoSugar
 import upickle.default._
 
 import scala.collection.mutable
@@ -20,12 +22,25 @@ class ProcessPublisherTest extends FreeSpec {
     val mockMessagingSystem = new MessagingSystem {
       val publishedMessages = mutable.ArrayBuffer[(String, String)]()
 
-      override def publish(topic: String, message: String): Unit = {
+      override def publish(topic: String, message: String)(implicit log: LoggingAdapter): Unit = {
         publishedMessages.append(topic -> message)
       }
     }
 
+    val mockLog = new LoggingAdapter {
+      override protected def notifyInfo(message: String): Unit = {}
+      override def isErrorEnabled: Boolean = false
+      override def isInfoEnabled: Boolean = false
+      override def isDebugEnabled: Boolean = false
+      override protected def notifyError(message: String): Unit = {}
+      override protected def notifyError(cause: Throwable, message: String): Unit = {}
+      override def isWarningEnabled: Boolean = false
+      override protected def notifyWarning(message: String): Unit = {}
+      override protected def notifyDebug(message: String): Unit = {}
+    }
+
     val publisher = new ProcessPublisher {
+      val log = mockLog
       override def jobId: String = "TestJob"
 
       override def publisher: MessagingSystem = mockMessagingSystem


### PR DESCRIPTION
Catch exceptions thrown by messagingSystem initialization in EigenflowBootstrap and terminate actor system.
